### PR TITLE
Hacer que el juego nunca termine, re posicionando los balones al salir de la ventana

### DIFF
--- a/cannon.py
+++ b/cannon.py
@@ -57,6 +57,10 @@ def move():
     for target in targets:
         target.x -= 0.5
 
+        if target.x < -210:
+            target.x = 200
+            target.y = randrange(-150, 150)
+
     if inside(ball):
         speed.y -= 0.35
         ball.move(speed)
@@ -70,10 +74,7 @@ def move():
 
     draw()
 
-    for target in targets:
-        if not inside(target):
-            return
-
+   
     ontimer(move, 50)
 
 
@@ -84,3 +85,4 @@ tracer(False)
 onscreenclick(tap)
 move()
 done()
+


### PR DESCRIPTION
En este cambio se modifica la lógica del juego Cannon para que sea infinito. Ahora, cuando los balones salen de la ventana, se re posicionan dentro del área de juego, evitando que el programa termine.